### PR TITLE
Make toArray conversion recursive

### DIFF
--- a/src/Traits/CanArray.php
+++ b/src/Traits/CanArray.php
@@ -2,10 +2,17 @@
 
 namespace Equip\Structure\Traits;
 
+use Equip\Structure\StructureInterface;
+
 trait CanArray /* implements StructureInterface */
 {
     public function toArray()
     {
-        return $this->values;
+        return array_map(static function ($value) {
+            if ($value instanceof StructureInterface) {
+                $value = $value->toArray();
+            }
+            return $value;
+        }, $this->values);
     }
 }

--- a/tests/ArrayRecursionTest.php
+++ b/tests/ArrayRecursionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Equip\Structure;
+
+use PHPUnit_Framework_TestCase as TestCase;
+
+class ArrayRecursionTest extends TestCase
+{
+    public function testToArray()
+    {
+        $books_by_lee = [
+            'To Kill a Mockingbird',
+            'Go Set a Watchman',
+        ];
+
+        $books_by_wilder = [
+            'Little House in the Big Woods',
+            'Little House on the Prairie',
+        ];
+
+        $books = new Dictionary([
+            'Harper Lee' => new OrderedList($books_by_lee),
+            'Laura Ingles Wilder' => new OrderedList($books_by_wilder),
+        ]);
+
+        $expect = [
+            'Harper Lee' => $books_by_lee,
+            'Laura Ingles Wilder' => $books_by_wilder,
+        ];
+
+        $this->assertSame($expect, $books->toArray());
+    }
+}


### PR DESCRIPTION
Fetching a flat array from a complex structure is often valuable for
data transmission.
